### PR TITLE
handle special characters

### DIFF
--- a/lib/hydra/remote_identifier/remote_services/doi.rb
+++ b/lib/hydra/remote_identifier/remote_services/doi.rb
@@ -34,7 +34,7 @@ module Hydra::RemoteIdentifier
       end
 
       def remote_uri_for(identifier)
-        URI.parse(File.join(resolver_url, normalize_identifier(identifier)))
+        URI.parse(File.join(resolver_url, normalize_identifier(escaped identifier)))
       end
 
       REQUIRED_ATTRIBUTES = ['target', 'creator', 'title', 'publisher', 'publicationyear', 'status', 'identifier_url' ].freeze
@@ -85,6 +85,14 @@ module Hydra::RemoteIdentifier
 
       def doi_service_url(identifier)
         File.join(url, 'id', identifier)
+      end
+
+      def escaped(identifier)
+        URI.escape(identifier).
+          gsub("[","%5B").
+          gsub("]","%5D").
+          gsub("+","%2B").
+          gsub("?","%3F")
       end
     end
   end

--- a/spec/fixtures/cassettes/doi-create.yml
+++ b/spec/fixtures/cassettes/doi-create.yml
@@ -133,4 +133,51 @@ http_interactions:
       string: 'error: bad request - no such identifier'
     http_version: 
   recorded_at: Mon, 15 Feb 2016 13:28:53 GMT
-recorded_with: VCR 3.0.1
+- request:
+    method: post
+    uri: https://ezid.lib.purdue.edu/shoulder/doi:10.5072/FK2
+    body:
+      encoding: UTF-8
+      string: |-
+        _target: http://google.com
+        _status: public
+        datacite.creator: Jeremy Friesen, Rajesh Balekai
+        datacite.title: My Article
+        datacite.publisher: Me Myself and I
+        datacite.publicationyear: 2013
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - text/plain
+      Content-Length:
+      - '185'
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YXBpdGVzdDphcGl0ZXN0
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Tue, 21 Feb 2017 16:14:17 GMT
+      Server:
+      - Apache/2.2.17 (Unix) mod_ssl/2.2.17 OpenSSL/1.0.1k-fips mod_wsgi/4.4.9 Python/2.7.12
+      Content-Length:
+      - '55'
+      Vary:
+      - Accept-Language,Cookie
+      Content-Language:
+      - en
+      Content-Type:
+      - text/plain; charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: 'success: doi:10.5072/FK2PZ57796 | ark:/b5072/fk2pz57796'
+    http_version: 
+  recorded_at: Tue, 21 Feb 2017 16:14:18 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/cassettes/doi-integration.yml
+++ b/spec/fixtures/cassettes/doi-integration.yml
@@ -13,7 +13,7 @@ http_interactions:
         datacite.publicationyear: 2013
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       Content-Type:
@@ -57,7 +57,7 @@ http_interactions:
         datacite.publicationyear: 2013
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       Content-Type:
@@ -88,4 +88,51 @@ http_interactions:
       string: 'success: doi:10.5072/FK2NC6D3G | ark:/b5072/fk2nc6d3g'
     http_version: 
   recorded_at: Fri, 14 Mar 2014 14:23:38 GMT
-recorded_with: VCR 2.6.0
+- request:
+    method: post
+    uri: https://ezid.lib.purdue.edu/shoulder/doi:10.5072/FK2
+    body:
+      encoding: UTF-8
+      string: |-
+        _target: http://google.com
+        _status: public
+        datacite.creator: my creator
+        datacite.title: my title
+        datacite.publisher: my publisher
+        datacite.publicationyear: 2013
+    headers:
+      Accept:
+      - text/plain
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - text/plain
+      Content-Length:
+      - '160'
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic YXBpdGVzdDphcGl0ZXN0
+  response:
+    status:
+      code: 201
+      message: CREATED
+    headers:
+      Date:
+      - Tue, 21 Feb 2017 16:14:18 GMT
+      Server:
+      - Apache/2.2.17 (Unix) mod_ssl/2.2.17 OpenSSL/1.0.1k-fips mod_wsgi/4.4.9 Python/2.7.12
+      Content-Length:
+      - '55'
+      Vary:
+      - Accept-Language,Cookie
+      Content-Language:
+      - en
+      Content-Type:
+      - text/plain; charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: 'success: doi:10.5072/FK2K64HF49 | ark:/b5072/fk2k64hf49'
+    http_version: 
+  recorded_at: Tue, 21 Feb 2017 16:14:19 GMT
+recorded_with: VCR 3.0.3

--- a/spec/lib/hydra/remote_identifier/remote_services/doi_spec.rb
+++ b/spec/lib/hydra/remote_identifier/remote_services/doi_spec.rb
@@ -20,8 +20,8 @@ module Hydra::RemoteIdentifier
       let(:expected_doi) {
         # From the doi-create cassette
         {
-          identifier: "doi:10.5072/FK23J3QV8",
-          identifier_url: "https://ezid.lib.purdue.edu/id/doi:10.5072/FK23J3QV8"
+          identifier: "doi:10.5072/FK2PZ57796",
+          identifier_url: "https://ezid.lib.purdue.edu/id/doi:10.5072/FK2PZ57796"
         }
       }
       subject { RemoteServices::Doi.new(configuration) }
@@ -59,6 +59,10 @@ module Hydra::RemoteIdentifier
         let(:expected_uri) { URI.parse(File.join(subject.resolver_url, expected_doi.fetch(:identifier)))}
         it 'should be based on configuration' do
           expect(subject.remote_uri_for(expected_doi.fetch(:identifier))).to eq(expected_uri)
+        end
+
+        it 'should handle charaters that need to be escaped' do
+          expect(subject.remote_uri_for("[test]{me}+")).to eq(URI.parse("http://dx.doi.org/%5Btest%5D%7Bme%7D%2B"))
         end
       end
     end

--- a/spec/lib/hydra/remote_identifier_spec.rb
+++ b/spec/lib/hydra/remote_identifier_spec.rb
@@ -18,7 +18,7 @@ module Hydra::RemoteIdentifier
 
     let(:target) { target_class.new }
     let(:expected_doi) {
-      {:identifier=>"doi:10.5072/FK2FT8XZZ", :identifier_url=>"https://ezid.lib.purdue.edu/id/doi:10.5072/FK2FT8XZZ"} # From the doi-create cassette
+      {:identifier=>"doi:10.5072/FK2K64HF49", :identifier_url=>"https://ezid.lib.purdue.edu/id/doi:10.5072/FK2K64HF49"} # From the doi-create cassette
     }
     let(:doi_options) { RemoteServices::Doi::TEST_CONFIGURATION }
 


### PR DESCRIPTION
Running the specs forced some updates to the cassettes, which forced some small updates to unrelated specs.

The core changes are those in `lib/hydra/remote_identifier/remote_services/doi.rb`