### PR TITLE
Change DOI link. Ucrate issue #773

### DIFF
--- a/lib/hydra/remote_identifier/remote_services/doi.rb
+++ b/lib/hydra/remote_identifier/remote_services/doi.rb
@@ -129,7 +129,7 @@ module Hydra::RemoteIdentifier
       end
 
       def default_resolver_url
-        'http://dx.doi.org/'
+        'https://doi.org/'
       end
 
       def doi_service_url(identifier)


### PR DESCRIPTION
Changes the DOI link from http://dx.doi.org to https://doi.org/